### PR TITLE
Fix job exporter crash

### DIFF
--- a/src/job-exporter/src/network.py
+++ b/src/job-exporter/src/network.py
@@ -214,7 +214,7 @@ def get_interfaces():
     return result
 
 
-def get_ip_can_access_internet(target="hub.docker.com"):
+def get_ip_can_access_internet(target="baidu.com"):
     """ return None on error """
     s = socket.socket(
             socket.AF_INET, socket.SOCK_STREAM)


### PR DESCRIPTION
fix https://github.com/microsoft/pai/issues/5570 by changing hub.docker.com to baidu.com, because hub.docker.com is often unreachable, but baidu.com is reachable worldwide.

Signed-off-by: siaimes <34199488+siaimes@users.noreply.github.com>